### PR TITLE
fix config references in training pipelines

### DIFF
--- a/DaCy/project.yml
+++ b/DaCy/project.yml
@@ -6,7 +6,7 @@ description: >
     format and training and evaluating the model. The template uses the `BotXO`
     transformer for Danish downloaded via. Huggingface.
 
-    You can run from til yaml file using
+    You can run from yaml file using
     spacy project run WORKFLOW/COMMAND
 
     for instance you might want to run the workflow "all" to run the entire pipeline:
@@ -15,7 +15,6 @@ description: >
 
 # Variables can be referenced across the project.yml using ${vars.var_name}
 vars:
-  config: "config"
   lang: "da"
   dataset: "dane"
   train_name: "dane_train"
@@ -101,7 +100,7 @@ commands:
     deps:
       - "corpus/${vars.dataset}/train.spacy"
       - "corpus/${vars.dataset}/dev.spacy"
-      - "configs/${vars.config}.cfg"
+      - "configs/${vars.config}_medium.cfg"
     outputs:
       - "training/${vars.dataset}/model-last"
 
@@ -112,7 +111,7 @@ commands:
     deps:
       - "corpus/${vars.dataset}/train.spacy"
       - "corpus/${vars.dataset}/dev.spacy"
-      - "configs/${vars.config}.cfg"
+      - "configs/${vars.config}_large.cfg"
     outputs:
       - "training/${vars.dataset}/model-last"
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ DaCy is a Danish preprocessing pipeline trained in SpaCy. At the time of writing
 ## Reproduction
 the folder `DaCy` contains a SpaCy project which will allow for a reproduction of the results. This folder also includes the evaluation metrics on DaNE.
 
+For further instructions on this look up the project file `DaCy/project.yml`.
+
 ## Usage
 
 To load in the project using the direct download simple place the downloaded "packages" folder in your directory load the model using SpaCy:


### PR DESCRIPTION
Hi

First of all - THANKS for open-sourcing this project. Looks great!

I just gave DaCy training pipelines a spin.

I have tried to fix the env variables, so that they point to the right config files in the project.yml file.

Also I suggest that you refer to the project file in README.

Best,
Lars


